### PR TITLE
TextField supports className

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html) since v1.0.0.
 
 ## [Unreleased]
+### Added
+- `className`support for `TextField`
+
 ### Changed
 - Using TypeScript as main languages
 - **BREACKING CHANGES**. Existing alternative package endpoints are removed for now.

--- a/src/components/forms/TextField/TextField.tsx
+++ b/src/components/forms/TextField/TextField.tsx
@@ -25,6 +25,7 @@ export const TextField: React.FC<FormProps & TextFieldProps> = props => {
     hideErrors,
     value: externalValue,
     isRequired,
+    className,
   } = props
 
   const [value, setValue] = useState(externalValue || '')
@@ -75,6 +76,7 @@ export const TextField: React.FC<FormProps & TextFieldProps> = props => {
             !isValid && errorStyle,
             isDisabled && disabledStyle,
           ]}
+          className={className}
           value={value}
           onChange={event => handleChanges(event.target.value)}
           placeholder={placeholder}
@@ -90,6 +92,7 @@ export const TextField: React.FC<FormProps & TextFieldProps> = props => {
             !isValid && errorStyle,
             isDisabled && disabledStyle,
           ]}
+          className={className}
           value={value}
           onChange={event => handleChanges(event.target.value)}
           placeholder={placeholder}
@@ -107,4 +110,5 @@ export interface TextFieldProps {
   rowCount?: number
   isHighlighted?: boolean
   hideErrors?: boolean
+  className?: string
 }


### PR DESCRIPTION
For easy customization, the `TextField` component should support the regular `className` attribute