### PR TITLE
Add onBlur support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - `className`support for `TextField`
+- `onBlur`support for `TextField`
 
 ### Changed
 - Using TypeScript as main languages

--- a/src/components/forms/TextField/TextField.tsx
+++ b/src/components/forms/TextField/TextField.tsx
@@ -32,7 +32,7 @@ export const TextField: React.FC<FormProps & TextFieldProps> = props => {
   const [errorMessages, setErrorMessages] = useState({})
   const [isValid, setValidity] = useState(true)
 
-  const { onValueChange = () => {}, onErrors = () => {} } = props
+  const { onValueChange = () => {}, onErrors = () => {}, onBlur = () => {} } = props
 
   const handleChanges = (v: string) => {
     setValue(v)
@@ -81,6 +81,7 @@ export const TextField: React.FC<FormProps & TextFieldProps> = props => {
           onChange={event => handleChanges(event.target.value)}
           placeholder={placeholder}
           disabled={isDisabled}
+          onBlur={() => onBlur()}
         />
       ) : null}
       {rowCount >= 2 ? (
@@ -98,6 +99,7 @@ export const TextField: React.FC<FormProps & TextFieldProps> = props => {
           placeholder={placeholder}
           rows={rowCount}
           disabled={isDisabled}
+          onBlur={() => onBlur()}
         />
       ) : null}
       <FormErrors errors={errorMessages} />

--- a/src/components/forms/form-props.ts
+++ b/src/components/forms/form-props.ts
@@ -5,4 +5,5 @@ export interface FormProps {
   isRequired?: boolean
   onValueChange?: (value: string) => void
   onErrors?: (errors: { [errorKey: string]: any }) => void
+  onBlur?: () => void
 }


### PR DESCRIPTION
For some lifecycle hooks users need to execute code at `onBlur` event. The PR adds the support for the `onBlur` attribute.