### PR TITLE
TextfieldList accept value attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html) since v1.0.0.
 
 ## [Unreleased]
+### Added
+- `TextFieldList` uses its `value` attribute as expected (to set the values)
+
+### Fixed
+- `TextFieldList`'s `value` attribute has a new type which is `string[]`!
+
 ## [v0.0.14] - 2019-10-09
 ### Fixed
 - `value` is now optional on all form components

--- a/src/components/forms/TextFieldList/TextFieldList.tsx
+++ b/src/components/forms/TextFieldList/TextFieldList.tsx
@@ -21,7 +21,14 @@ import { FormProps } from '../form-props'
 export const TextFieldList: React.FC<
   FormProps & TextFieldListProps
 > = props => {
-  const [values, setValues] = useState<{ id: string; text: string }[]>([])
+  const intialValues = props.value != null
+    ? props.value
+        .map(el => ({
+          id: RandomString.generate(20),
+          text: el
+        }))
+    : []
+  const [values, setValues] = useState<{ id: string; text: string }[]>(intialValues)
   const [errorMessages, setErrorMessages] = useState<{
     [errorKey: string]: any
   }>({})
@@ -134,5 +141,6 @@ export interface TextFieldListProps {
   initalFieldCount?: number
   buttonText?: string
   displayErrorStrategy?: 'hidden' | 'on-field' | 'on-list'
+  value?: string[]
   onValueChange?: (values: string[]) => void
 }

--- a/stories/text-field-list.stories.js
+++ b/stories/text-field-list.stories.js
@@ -18,13 +18,15 @@ storiesOf('Components|Forms/TextFieldList', module)
   .addDecorator(withKnobs)
   .add('normal state', () => {
     const Story = () => {
-      const [values, setValues] = useState([])
+      const intialValues = boolean('inital field values', true) ? ['yes', 'no', 'maybe'] : []
+      const [values, setValues] = useState(intialValues)
 
       return (
         <>
           <TextFieldList
             placeholder={text('placeholder', 'Add your text here')}
-            initalFieldCount={number('initial field count', 3)}
+            initalFieldCount={number('initial field count', 2)}
+            value={values}
             onValueChange={values => setValues(values)}
           />
           <pre


### PR DESCRIPTION
Actualy the `TextFieldList` component was accepting a `value` attribute but didn't use it.

As the `value` attribute wasn't used, its type was the default one for form components. The type is now fixed and value used to fill the list of fields.