### PR TITLE
Fix on v20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,6 +186,7 @@ be rendered as an `a`, a `button` or a `Link` from `react-router-dom`
 - Setup storybook as documentation
 
 [Unreleased]: https://github.com/ferpection/uikit/tree/master
+[v0.0.20]: https://github.com/ferpection/uikit/tree/v0.0.20
 [v0.0.19]: https://github.com/ferpection/uikit/tree/v0.0.19
 [v0.0.18]: https://github.com/ferpection/uikit/tree/v0.0.18
 [v0.0.17]: https://github.com/ferpection/uikit/tree/v0.0.17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ and this project **don't** adheres to [Semantic Versioning](http://semver.org/sp
 ## [Unreleased]
 
 ## [v0.0.20] - 2019-11-04
-- Fix checkbox
-- Fix list on Firefox
+### Fixed
+- Display a v-check on `CheckboxButton`
+- `TextFieldList` is now the rendered the same on Firefox as other browsers
 
 ## [v0.0.19] - 2019-10-28
 ### Added

--- a/src/components/buttons/CheckboxButton/styles.ts
+++ b/src/components/buttons/CheckboxButton/styles.ts
@@ -2,7 +2,7 @@ import { css } from '@emotion/core'
 
 import { SANSSERIF_FONTSET } from '../../../fonts'
 import { N200_COLOR, N300_COLOR, C200_COLOR, N75_COLOR, N100_COLOR, C15_COLOR } from '../../../colors'
-import a from '../../iconography/icon-check-white.svg'
+import checkIcon from '../../iconography/icon-check-white.svg'
 
 export const checkboxStyles = css`
   appearance: none;
@@ -35,7 +35,7 @@ export const checkboxStyles = css`
   }
   input[type='checkbox']:checked + & {
     border-color: ${`${C200_COLOR}`};
-    background: url(${a}) 2px 2px no-repeat ${`${C200_COLOR}`};
+    background: url(${checkIcon}) 2px 2px no-repeat ${`${C200_COLOR}`};
     background-size: 13px;
   }
   input[type='checkbox']:disabled + & {


### PR DESCRIPTION
# Actual
<img width="397" alt="Capture d’écran 2019-11-05 à 08 27 08" src="https://user-images.githubusercontent.com/3090112/68187732-ac7ceb80-ffa7-11e9-9a82-eaaa08065042.png">

# Fixes
- Create a tag for v0.0.20
- Add link targeting v0.0.20 on CHANGELOG
- Rewrite some CHANGELOG lines
- Rename the SVG import variable