### PR TITLE
TextfieldList can be used w/o value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Using a new `useExternalDragHandle` attribute on a `ReorderableList` component,
   the user can enable the `DragHandle` capabilities.
 
+### Fixed
+- `TextFieldList` can used again without value attribute.
+
 ## [v0.1.1] - 2019-02-14
 ### Fixed
 - `TextFieldList` do not loose focus when the user is writing something.

--- a/src/components/forms/TextFieldList/TextFieldList.tsx
+++ b/src/components/forms/TextFieldList/TextFieldList.tsx
@@ -46,7 +46,7 @@ export const TextFieldList: React.FC<TextFieldListProps> = props => {
   useEffect(() => onValueChange(values.map(value => value.text)), [values])
   useEffect(() => onErrors(flatErrorMessages), [errorMessages])
   useEffect(() => {
-    const mergedValue = props.value.reduce((aggr, curr, index) => {
+    const mergedValue = (props.value || []).reduce((aggr, curr, index) => {
       const { id = RandomString.generate(20) } = values[index]
 
       return [

--- a/src/components/forms/TextFieldList/TextFieldList.tsx
+++ b/src/components/forms/TextFieldList/TextFieldList.tsx
@@ -22,14 +22,14 @@ import {
 } from './styles'
 
 export const TextFieldList: React.FC<TextFieldListProps> = props => {
-  const intialValues =
-    props.value != null
-      ? props.value.map(el => ({
-        id: RandomString.generate(20),
-        text: el,
-      }))
-      : []
+  const flatInitialValues = props.value || []
+  const intialValues = flatInitialValues.map(el => ({
+    id: RandomString.generate(20),
+    text: el,
+  }))
+
   const [values, setValues] = useState<{ id: string; text: string }[]>(intialValues)
+  const [handleFocus, handleBlur] = useMergedFocusHandlers(props)
   const [errorMessages, setErrorMessages] = useState<{
     [errorKey: string]: any
   }>({})
@@ -41,12 +41,10 @@ export const TextFieldList: React.FC<TextFieldListProps> = props => {
       return Object.assign({}, aggr, curr)
     }, {})
 
-  const [handleFocus, handleBlur] = useMergedFocusHandlers(props)
-
   useEffect(() => onValueChange(values.map(value => value.text)), [values])
   useEffect(() => onErrors(flatErrorMessages), [errorMessages])
   useEffect(() => {
-    const mergedValue = (props.value || []).reduce((aggr, curr, index) => {
+    const mergedValue = flatInitialValues.reduce((aggr, curr, index) => {
       const { id = RandomString.generate(20) } = values[index]
 
       return [
@@ -59,7 +57,7 @@ export const TextFieldList: React.FC<TextFieldListProps> = props => {
     }, [])
 
     setValues(mergedValue)
-  }, [...(props.value || [])])
+  }, [...flatInitialValues])
 
   const {
     isDisabled,


### PR DESCRIPTION
Given the API the `value` attribute is optional on `TextFieldList`. This PR makes it true again.