### PR TITLE
Improve SelectField component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   the user can enable the `DragHandle` capabilities.
 - User can display a smaller version of `SelectField`.
 
+### Fixed
+- Add an option to test the small version of `TextField` in storybook.
+
 ## [v0.1.1] - 2019-02-14
 ### Fixed
 - `TextFieldList` do not loose focus when the user is writing something.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Using a new `useExternalDragHandle` attribute on a `ReorderableList` component,
   the user can enable the `DragHandle` capabilities.
 - User can display a smaller version of `SelectField`.
+- `SelectField` support the `className` attribute.
 
 ### Fixed
 - Add an option to test the small version of `TextField` in storybook.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   the user can enable the `DragHandle` capabilities.
 - User can display a smaller version of `SelectField`.
 - `SelectField` support the `className` attribute.
+- `SelectField` support the `hideErrors` attribute. When used no error message is displayed
+  but the field still shows the error state.
 
 ### Fixed
 - Add an option to test the small version of `TextField` in storybook.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   The goals is to delegate to the user the choice of what can trigger the dragn'drop behavior.
 - Using a new `useExternalDragHandle` attribute on a `ReorderableList` component,
   the user can enable the `DragHandle` capabilities.
+- User can display a smaller version of `SelectField`.
 
 ## [v0.1.1] - 2019-02-14
 ### Fixed

--- a/src/components/forms/SelectField/SelectField.tsx
+++ b/src/components/forms/SelectField/SelectField.tsx
@@ -9,7 +9,7 @@ import { FormProps } from '../form-props'
 import { baseStyle, placehoderStyle, highlightedStyle, disabledStyle, errorStyle, smallStyle } from './styles'
 
 export const SelectField: React.FC<SelectFieldProps> = props => {
-  const { placeholder, isHighlighted, isDisabled, isRequired, isSmall = false, value: externalValue, children } = props
+  const { value: externalValue } = props
 
   const { addTranslations } = useContext(I18nContext)
   const [value, setValue] = useState(externalValue || '')
@@ -33,6 +33,7 @@ export const SelectField: React.FC<SelectFieldProps> = props => {
     onErrors = (e: { [errorKey: string]: any }) => setErrorMessages(e),
     onFocus: handleFocus = () => {},
     onBlur: handleBlur = () => {},
+    isRequired,
   } = props
 
   const isEmpty = value == null || value === ''
@@ -57,7 +58,14 @@ export const SelectField: React.FC<SelectFieldProps> = props => {
     onErrors(errors)
   }, [value])
 
-  const { className } = props
+  const {
+    className,
+    isSmall = false,
+    placeholder,
+    isHighlighted,
+    isDisabled,
+    children,
+  } = props
 
   return (
     <Fragment>

--- a/src/components/forms/SelectField/SelectField.tsx
+++ b/src/components/forms/SelectField/SelectField.tsx
@@ -57,6 +57,8 @@ export const SelectField: React.FC<SelectFieldProps> = props => {
     onErrors(errors)
   }, [value])
 
+  const { className } = props
+
   return (
     <Fragment>
       <select
@@ -68,6 +70,7 @@ export const SelectField: React.FC<SelectFieldProps> = props => {
           isDisabled && disabledStyle,
           isSmall && smallStyle,
         ]}
+        className={className}
         disabled={isDisabled}
         value={value}
         onChange={event => handleChanges(event)}
@@ -84,6 +87,7 @@ export const SelectField: React.FC<SelectFieldProps> = props => {
 
 export interface SelectFieldProps extends FormProps {
   isHighlighted: boolean
+  className?: string
   isSmall?: boolean
   value?: string
   onValueChange?: (value: string, event: SyntheticEvent) => void

--- a/src/components/forms/SelectField/SelectField.tsx
+++ b/src/components/forms/SelectField/SelectField.tsx
@@ -6,10 +6,10 @@ import { I18nContext } from '../../contexts/I18nContext'
 import { FormErrorMessages } from '../FormErrorMessages/FormErrorMessages'
 import { FormProps } from '../form-props'
 
-import { baseStyle, placehoderStyle, highlightedStyle, disabledStyle, errorStyle } from './styles'
+import { baseStyle, placehoderStyle, highlightedStyle, disabledStyle, errorStyle, smallStyle } from './styles'
 
 export const SelectField: React.FC<SelectFieldProps> = props => {
-  const { placeholder, isHighlighted, isDisabled, isRequired, value: externalValue, children } = props
+  const { placeholder, isHighlighted, isDisabled, isRequired, isSmall = false, value: externalValue, children } = props
 
   const { addTranslations } = useContext(I18nContext)
   const [value, setValue] = useState(externalValue || '')
@@ -66,6 +66,7 @@ export const SelectField: React.FC<SelectFieldProps> = props => {
           isHighlighted && highlightedStyle,
           !isValid && errorStyle,
           isDisabled && disabledStyle,
+          isSmall && smallStyle,
         ]}
         disabled={isDisabled}
         value={value}
@@ -83,6 +84,7 @@ export const SelectField: React.FC<SelectFieldProps> = props => {
 
 export interface SelectFieldProps extends FormProps {
   isHighlighted: boolean
+  isSmall?: boolean
   value?: string
   onValueChange?: (value: string, event: SyntheticEvent) => void
 }

--- a/src/components/forms/SelectField/SelectField.tsx
+++ b/src/components/forms/SelectField/SelectField.tsx
@@ -30,10 +30,11 @@ export const SelectField: React.FC<SelectFieldProps> = props => {
 
   const {
     onValueChange = () => {},
-    onErrors = (e: { [errorKey: string]: any }) => setErrorMessages(e),
+    onErrors = () => {},
     onFocus: handleFocus = () => {},
     onBlur: handleBlur = () => {},
     isRequired,
+    hideErrors,
   } = props
 
   const isEmpty = value == null || value === ''
@@ -56,6 +57,10 @@ export const SelectField: React.FC<SelectFieldProps> = props => {
 
     setValidity(Object.keys(errors).length <= 0)
     onErrors(errors)
+
+    if (!hideErrors) {
+      setErrorMessages(errors)
+    }
   }, [value])
 
   const {
@@ -97,6 +102,7 @@ export interface SelectFieldProps extends FormProps {
   isHighlighted: boolean
   className?: string
   isSmall?: boolean
+  hideErrors?: boolean
   value?: string
   onValueChange?: (value: string, event: SyntheticEvent) => void
 }

--- a/src/components/forms/SelectField/styles.ts
+++ b/src/components/forms/SelectField/styles.ts
@@ -75,3 +75,10 @@ export const errorStyle = css`
     box-shadow: 0 0 0 16px ${C200_COLOR.toRGBA(0.1)};
   }
 `
+
+export const smallStyle = css`
+  padding: 0;
+  max-width: max-content;
+  display: inline-block;
+  text-align: center;
+`

--- a/src/components/forms/SelectField/styles.ts
+++ b/src/components/forms/SelectField/styles.ts
@@ -77,6 +77,7 @@ export const errorStyle = css`
 `
 
 export const smallStyle = css`
+  height: 22px;
   padding: 0;
   max-width: max-content;
   display: inline-block;

--- a/stories/select-field.stories.js
+++ b/stories/select-field.stories.js
@@ -24,5 +24,6 @@ storiesOf('Components|Forms/SelectField', module)
       dataType={select('data type', ['text', 'email'])}
       isHighlighted={boolean('highlighted', false)}
       isDisabled={boolean('disabled', false)}
+      isSmall={boolean('is small', false)}
     />
   ))

--- a/stories/text-field.stories.js
+++ b/stories/text-field.stories.js
@@ -48,5 +48,6 @@ storiesOf('Components|Forms/TextField', module)
       rowCount={number('row count', 1)}
       isHighlighted={boolean('highlighted', false)}
       isDisabled={boolean('disabled', false)}
+      isSmall={boolean('is small', false)}
     />
   ))


### PR DESCRIPTION
The PR improves the `SelectField` component to makes it as powerful as the `TextField` component.

- [x] `SelectField` has a *small* version
- [x] `SelectField` supports the `className` attribute
- [x] `SelectField` supports the `hideErrors` attribute