### PR TITLE
Date picker responsive

### DIFF
--- a/src/components/forms/DatePickerField/Calendar/Calendar.tsx
+++ b/src/components/forms/DatePickerField/Calendar/Calendar.tsx
@@ -27,6 +27,8 @@ export interface CalendarProps extends DayzedProps {
   language: string
   previousButtonLabel?: string
   nextButtonLabel?: string
+  cancelButtonLabel?: string
+  onClose?: () => void
 }
 
 export function Calendar(props: PropsWithChildren<CalendarProps>) {
@@ -37,6 +39,8 @@ export function Calendar(props: PropsWithChildren<CalendarProps>) {
     language,
     previousButtonLabel,
     nextButtonLabel,
+    cancelButtonLabel,
+    onClose = () => {},
   } = props
   const { calendars, getBackProps, getDateProps, getForwardProps } = useDayzed(props)
 
@@ -59,10 +63,15 @@ export function Calendar(props: PropsWithChildren<CalendarProps>) {
       isSmall={isSmall}
       previousButtonArgs={getBackProps({ calendars })}
       nextButtonArgs={getForwardProps({ calendars })}
+      cancelButtonArgs={{ onClick: onClose }}
       previousButtonLabel={previousButtonLabel}
       nextButtonLabel={nextButtonLabel}
+      cancelButtonLabel={cancelButtonLabel}
     >
-      <div key={`${calendar.month}${calendar.year}`}>
+      <div
+        key={`${calendar.month}${calendar.year}`}
+        style={{ display: 'inline-flex', justifyContent: 'space-between', flexWrap: 'wrap' }}
+      >
         {weekdayNamesShort.map(weekday => (
           <div key={`${calendar.month}${calendar.year}${weekday}`} css={[headerWeekday]}>
             {weekday}

--- a/src/components/forms/DatePickerField/Calendar/DatePickerButton/styles.ts
+++ b/src/components/forms/DatePickerField/Calendar/DatePickerButton/styles.ts
@@ -6,4 +6,9 @@ export const cicleButton = css`
   border-radius: 50%;
   height: ${buttonWidth}px;
   width: ${buttonWidth}px;
+
+  @media (max-width: 400px) {
+    height: ${buttonWidth / 1.3}px;
+    width: ${buttonWidth / 1.3}px;
+  }
 `

--- a/src/components/forms/DatePickerField/Calendar/styles.ts
+++ b/src/components/forms/DatePickerField/Calendar/styles.ts
@@ -6,6 +6,7 @@ const buttonWidth = 40
 export const calendarBoard = css`
   display: flex;
   flex-wrap: wrap;
+  justify-content: space-between;
 `
 
 export const headerWeekday = css`
@@ -29,6 +30,11 @@ export const headerWeekday = css`
     background-color: transparent;
     color: ${`${N500_COLOR}`};
   }
+
+  @media (max-width: 400px) {
+    font-size: 0.8em;
+    width: ${buttonWidth / 1.3}px;
+  }
 `
 
 export const emptyButtonSpace = css`
@@ -48,5 +54,10 @@ export const emptyButtonSpace = css`
   &:focus {
     background-color: transparent;
     color: ${`${N500_COLOR}`};
+  }
+
+  @media (max-width: 400px) {
+    height: ${buttonWidth / 1.3}px;
+    width: ${buttonWidth / 1.3}px;
   }
 `

--- a/src/components/forms/DatePickerField/CalendarContainer/CalendarContainer.tsx
+++ b/src/components/forms/DatePickerField/CalendarContainer/CalendarContainer.tsx
@@ -12,8 +12,10 @@ interface CalendarContainerProps {
   isSmall?: boolean
   previousButtonArgs?: Record<string, any>
   nextButtonArgs?: Record<string, any>
+  cancelButtonArgs?: Record<string, any>
   previousButtonLabel?: string
   nextButtonLabel?: string
+  cancelButtonLabel?: string
 }
 
 export function CalendarContainer({
@@ -23,6 +25,8 @@ export function CalendarContainer({
   previousButtonLabel = 'Previous',
   nextButtonArgs,
   nextButtonLabel = 'Next',
+  cancelButtonArgs,
+  cancelButtonLabel = 'Cancel',
   title,
 }: PropsWithChildren<CalendarContainerProps>) {
   const theme = useTheme()
@@ -39,6 +43,9 @@ export function CalendarContainer({
       </div>
       {title != null && <div css={[header]}>{title}</div>}
       <div css={calendarBoard}>{children}</div>
+      <Button actionType="negative" isFilled icon="times" isDisabled={nextButtonArgs == null} {...cancelButtonArgs}>
+        {cancelButtonLabel}
+      </Button>
     </div>
   )
 }

--- a/src/components/forms/DatePickerField/CalendarContainer/styles.ts
+++ b/src/components/forms/DatePickerField/CalendarContainer/styles.ts
@@ -26,6 +26,15 @@ export const calendarContainer = (theme: Theme) => css`
     box-shadow: 0 0 0 8px ${theme.colors.action.toRGBA(0.1)};
   }
   z-index: 3;
+
+  @media (max-width: 400px) {
+    width: 100%;
+    max-width: 100%;
+    height: 100%;
+    top: 0;
+    padding: 0;
+    justify-content: space-around;
+  }
 `
 
 export const smallCalendarContainer = (theme: Theme) => css`

--- a/src/components/forms/DatePickerField/DatePickerField.tsx
+++ b/src/components/forms/DatePickerField/DatePickerField.tsx
@@ -36,6 +36,7 @@ export interface DatePickerFieldProps extends FormProps {
   dateLanguage?: string
   previousButtonLabel?: string
   nextButtonLabel?: string
+  cancelButtonLabel?: string
   yearComponentTitle?: string
   monthComponentTitle?: string
 }
@@ -55,6 +56,7 @@ export function DatePickerField(props: PropsWithChildren<DatePickerFieldProps>) 
     dateLanguage = 'en',
     previousButtonLabel,
     nextButtonLabel,
+    cancelButtonLabel,
     yearComponentTitle,
     monthComponentTitle,
     ...otherProps
@@ -145,6 +147,7 @@ export function DatePickerField(props: PropsWithChildren<DatePickerFieldProps>) 
           <Calendar
             previousButtonLabel={previousButtonLabel}
             nextButtonLabel={nextButtonLabel}
+            cancelButtonLabel={cancelButtonLabel}
             language={dateLanguage}
             onDateSelected={({ date }) => {
               setValue(date)
@@ -156,6 +159,7 @@ export function DatePickerField(props: PropsWithChildren<DatePickerFieldProps>) 
 
               moveToNextSelector()
             }}
+            onClose={() => (modalState == null ? moveToSelector(0) : closeModal())}
             date={value || new Date()}
             selected={[value]}
             firstDayOfWeek={1}

--- a/src/components/forms/DatePickerField/styles.ts
+++ b/src/components/forms/DatePickerField/styles.ts
@@ -4,6 +4,10 @@ export const datePickerContainer = css`
   position: relative;
   display: inline-block;
   width: 100%;
+
+  @media (max-width: 400px) {
+    position: unset;
+  }
 `
 
 export const datePickerContainerSmall = css`

--- a/stories/form/date-picker-field.stories.js
+++ b/stories/form/date-picker-field.stories.js
@@ -18,24 +18,28 @@ const labels = {
   en: {
     buttonNext: 'Next',
     buttonPrevious: 'Previous',
+    buttonCancel: 'Cancel',
     years: 'Years',
     months: 'Months',
   },
   fr: {
     buttonNext: 'Suivant',
     buttonPrevious: 'Précédent',
+    buttonCancel: 'Annuler',
     years: 'Années',
     months: 'Mois',
   },
   zh_HANS: {
     buttonNext: '下一个',
     buttonPrevious: '上一个',
+    buttonCancel: '取消',
     years: '年',
     months: '月',
   },
   ko: {
     buttonNext: '다음',
     buttonPrevious: '이전',
+    buttonCancel: '취소',
     years: '연령',
     months: '개월',
     datePlaceholder: 'dd/mm/yyyy',
@@ -49,6 +53,7 @@ export const NormalState = ({ testLang, ...args }) => {
       dateLanguage={testLang}
       nextButtonLabel={labels[testLang].buttonNext}
       previousButtonLabel={labels[testLang].buttonPrevious}
+      cancelButtonLabel={labels[testLang].buttonCancel}
       monthComponentTitle={labels[testLang].months}
       yearComponentTitle={labels[testLang].years}
       {...args}
@@ -67,6 +72,7 @@ export const ErrorState = ({ testLang, ...args }) => {
         dateLanguage={testLang}
         nextButtonLabel={labels[testLang].buttonNext}
         previousButtonLabel={labels[testLang].buttonPrevious}
+        cancelButtonLabel={labels[testLang].buttonCancel}
         monthComponentTitle={labels[testLang].months}
         yearComponentTitle={labels[testLang].years}
         {...args}
@@ -76,6 +82,7 @@ export const ErrorState = ({ testLang, ...args }) => {
         dateLanguage={testLang}
         nextButtonLabel={labels[testLang].buttonNext}
         previousButtonLabel={labels[testLang].buttonPrevious}
+        cancelButtonLabel={labels[testLang].buttonCancel}
         monthComponentTitle={labels[testLang].months}
         yearComponentTitle={labels[testLang].years}
         {...args}
@@ -96,6 +103,7 @@ export const DisabledState = ({ testLang, ...args }) => {
         dateLanguage={testLang}
         nextButtonLabel={labels[testLang].buttonNext}
         previousButtonLabel={labels[testLang].buttonPrevious}
+        cancelButtonLabel={labels[testLang].buttonCancel}
         monthComponentTitle={labels[testLang].months}
         yearComponentTitle={labels[testLang].years}
         {...args}
@@ -124,6 +132,7 @@ export const BirthDateExample = ({ testLang, ...args }) => {
       dateLanguage={testLang}
       nextButtonLabel={labels[testLang].buttonNext}
       previousButtonLabel={labels[testLang].buttonPrevious}
+      cancelButtonLabel={labels[testLang].buttonCancel}
       monthComponentTitle={labels[testLang].months}
       yearComponentTitle={labels[testLang].years}
       {...args}
@@ -145,6 +154,7 @@ export const OneDateComponentBehavior = ({ testLang, ...args }) => {
         dateLanguage={testLang}
         nextButtonLabel={labels[testLang].buttonNext}
         previousButtonLabel={labels[testLang].buttonPrevious}
+        cancelButtonLabel={labels[testLang].buttonCancel}
         monthComponentTitle={labels[testLang].months}
         yearComponentTitle={labels[testLang].years}
         {...args}
@@ -155,6 +165,7 @@ export const OneDateComponentBehavior = ({ testLang, ...args }) => {
         dateLanguage={testLang}
         nextButtonLabel={labels[testLang].buttonNext}
         previousButtonLabel={labels[testLang].buttonPrevious}
+        cancelButtonLabel={labels[testLang].buttonCancel}
         monthComponentTitle={labels[testLang].months}
         yearComponentTitle={labels[testLang].years}
         {...args}
@@ -165,6 +176,7 @@ export const OneDateComponentBehavior = ({ testLang, ...args }) => {
         dateLanguage={testLang}
         nextButtonLabel={labels[testLang].buttonNext}
         previousButtonLabel={labels[testLang].buttonPrevious}
+        cancelButtonLabel={labels[testLang].buttonCancel}
         monthComponentTitle={labels[testLang].months}
         yearComponentTitle={labels[testLang].years}
         {...args}
@@ -186,6 +198,7 @@ export const TwoDateComponentsBehavior = ({ testLang, ...args }) => {
         dateLanguage={testLang}
         nextButtonLabel={labels[testLang].buttonNext}
         previousButtonLabel={labels[testLang].buttonPrevious}
+        cancelButtonLabel={labels[testLang].buttonCancel}
         monthComponentTitle={labels[testLang].months}
         yearComponentTitle={labels[testLang].years}
         {...args}
@@ -196,6 +209,7 @@ export const TwoDateComponentsBehavior = ({ testLang, ...args }) => {
         dateLanguage={testLang}
         nextButtonLabel={labels[testLang].buttonNext}
         previousButtonLabel={labels[testLang].buttonPrevious}
+        cancelButtonLabel={labels[testLang].buttonCancel}
         monthComponentTitle={labels[testLang].months}
         yearComponentTitle={labels[testLang].years}
         {...args}
@@ -206,6 +220,7 @@ export const TwoDateComponentsBehavior = ({ testLang, ...args }) => {
         dateLanguage={testLang}
         nextButtonLabel={labels[testLang].buttonNext}
         previousButtonLabel={labels[testLang].buttonPrevious}
+        cancelButtonLabel={labels[testLang].buttonCancel}
         monthComponentTitle={labels[testLang].months}
         yearComponentTitle={labels[testLang].years}
         {...args}
@@ -216,6 +231,7 @@ export const TwoDateComponentsBehavior = ({ testLang, ...args }) => {
         dateLanguage={testLang}
         nextButtonLabel={labels[testLang].buttonNext}
         previousButtonLabel={labels[testLang].buttonPrevious}
+        cancelButtonLabel={labels[testLang].buttonCancel}
         monthComponentTitle={labels[testLang].months}
         yearComponentTitle={labels[testLang].years}
         {...args}
@@ -226,6 +242,7 @@ export const TwoDateComponentsBehavior = ({ testLang, ...args }) => {
         dateLanguage={testLang}
         nextButtonLabel={labels[testLang].buttonNext}
         previousButtonLabel={labels[testLang].buttonPrevious}
+        cancelButtonLabel={labels[testLang].buttonCancel}
         monthComponentTitle={labels[testLang].months}
         yearComponentTitle={labels[testLang].years}
         {...args}
@@ -236,6 +253,7 @@ export const TwoDateComponentsBehavior = ({ testLang, ...args }) => {
         dateLanguage={testLang}
         nextButtonLabel={labels[testLang].buttonNext}
         previousButtonLabel={labels[testLang].buttonPrevious}
+        cancelButtonLabel={labels[testLang].buttonCancel}
         monthComponentTitle={labels[testLang].months}
         yearComponentTitle={labels[testLang].years}
         {...args}
@@ -257,6 +275,7 @@ export const ThreeDateComponentsBehavior = ({ testLang, ...args }) => {
         dateLanguage={testLang}
         nextButtonLabel={labels[testLang].buttonNext}
         previousButtonLabel={labels[testLang].buttonPrevious}
+        cancelButtonLabel={labels[testLang].buttonCancel}
         monthComponentTitle={labels[testLang].months}
         yearComponentTitle={labels[testLang].years}
         {...args}
@@ -267,6 +286,7 @@ export const ThreeDateComponentsBehavior = ({ testLang, ...args }) => {
         dateLanguage={testLang}
         nextButtonLabel={labels[testLang].buttonNext}
         previousButtonLabel={labels[testLang].buttonPrevious}
+        cancelButtonLabel={labels[testLang].buttonCancel}
         monthComponentTitle={labels[testLang].months}
         yearComponentTitle={labels[testLang].years}
         {...args}
@@ -277,6 +297,7 @@ export const ThreeDateComponentsBehavior = ({ testLang, ...args }) => {
         dateLanguage={testLang}
         nextButtonLabel={labels[testLang].buttonNext}
         previousButtonLabel={labels[testLang].buttonPrevious}
+        cancelButtonLabel={labels[testLang].buttonCancel}
         monthComponentTitle={labels[testLang].months}
         yearComponentTitle={labels[testLang].years}
         {...args}
@@ -287,6 +308,7 @@ export const ThreeDateComponentsBehavior = ({ testLang, ...args }) => {
         dateLanguage={testLang}
         nextButtonLabel={labels[testLang].buttonNext}
         previousButtonLabel={labels[testLang].buttonPrevious}
+        cancelButtonLabel={labels[testLang].buttonCancel}
         monthComponentTitle={labels[testLang].months}
         yearComponentTitle={labels[testLang].years}
         {...args}
@@ -297,6 +319,7 @@ export const ThreeDateComponentsBehavior = ({ testLang, ...args }) => {
         dateLanguage={testLang}
         nextButtonLabel={labels[testLang].buttonNext}
         previousButtonLabel={labels[testLang].buttonPrevious}
+        cancelButtonLabel={labels[testLang].buttonCancel}
         monthComponentTitle={labels[testLang].months}
         yearComponentTitle={labels[testLang].years}
         {...args}
@@ -307,6 +330,7 @@ export const ThreeDateComponentsBehavior = ({ testLang, ...args }) => {
         dateLanguage={testLang}
         nextButtonLabel={labels[testLang].buttonNext}
         previousButtonLabel={labels[testLang].buttonPrevious}
+        cancelButtonLabel={labels[testLang].buttonCancel}
         monthComponentTitle={labels[testLang].months}
         yearComponentTitle={labels[testLang].years}
         {...args}


### PR DESCRIPTION
This PR improves the `DatePickerField` to make it more responsive.

Changes:
- Open the modal in full screen when used on a small device
- New cancel button to be allowed to close the modal on full screen mode
- Smaller text on smaller screens

Open `DatePickerField` on large screen:
<img width="852" alt="Capture d’écran 2022-04-21 à 7 37 20 AM" src="https://user-images.githubusercontent.com/3090112/164382675-72054381-2dc4-42ad-870b-bbe628672f92.png">

Open `DatePickerField` on medium screen:
<img width="430" alt="Capture d’écran 2022-04-21 à 7 36 58 AM" src="https://user-images.githubusercontent.com/3090112/164382735-5292aed4-43f0-446d-8327-0a04211edab7.png">

Open `DatePickerField` on small screen:
<img width="353" alt="Capture d’écran 2022-04-21 à 7 37 08 AM" src="https://user-images.githubusercontent.com/3090112/164382768-0b3e008d-24fc-4c04-91e3-4412282c567f.png">

